### PR TITLE
Make format syntax compatible with i18n-abide

### DIFF
--- a/gobbledygook.js
+++ b/gobbledygook.js
@@ -18,7 +18,7 @@
 
   // take a string and turn it into an array of tokens.  Tokens are:
   // 1. text: plain text chunks
-  // 2. markers: untranslatable place holders %s or %(name)
+  // 2. markers: untranslatable place holders %s or %(name)s
   // 3. containers: like, <a> </a>. things containing text that should be translated,
   //    but the things must retain their order
   function tokenize(str) {
@@ -45,7 +45,7 @@
     function splitMarkers(arr) {
       for (var i = 0; i < arr.length; i++) {
         if (typeof arr[i] === 'string') {
-          var splt = resplit(arr[i], /(&[a-zA-Z]+;|&#[0-9]+;|%s|%\([^)]+\))/g);
+          var splt = resplit(arr[i], /(&[a-zA-Z]+;|&#[0-9]+;|%s|%\([^)]+\)s)/g);
           arr.splice(i--, 1);
           while (splt.length) {
             var x = splt.shift();

--- a/tests.js
+++ b/tests.js
@@ -10,14 +10,14 @@ const tests = [
 
   [ "Please close this window, <a %s>enable cookies</a> and try again",
     "uıaƃa ʎɹʇ pua <a %s>sǝıʞooɔ ǝʅqauǝ</a> ´ʍopuıʍ sıɥʇ ǝsoʅɔ ǝsaǝʅԀ" ],
-  [ "Please close this window, <a %(cookieLink)>enable <b>super dooper %(persona)</b> cookies</a> and try again",
-    "uıaƃa ʎɹʇ pua <a %(cookieLink)>sǝıʞooɔ <b>%(persona) ɹǝdoop ɹǝdns</b> ǝʅqauǝ</a> ´ʍopuıʍ sıɥʇ ǝsoʅɔ ǝsaǝʅԀ" ],
-  [ "%(aWebsite) uses Persona to sign you in!",
-    "¡uı noʎ uƃıs oʇ auosɹǝԀ sǝsn %(aWebsite)" ],
+  [ "Please close this window, <a %(cookieLink)s>enable <b>super dooper %(persona)s</b> cookies</a> and try again",
+    "uıaƃa ʎɹʇ pua <a %(cookieLink)s>sǝıʞooɔ <b>%(persona)s ɹǝdoop ɹǝdns</b> ǝʅqauǝ</a> ´ʍopuıʍ sıɥʇ ǝsoʅɔ ǝsaǝʅԀ" ],
+  [ "%(aWebsite)s uses Persona to sign you in!",
+    "¡uı noʎ uƃıs oʇ auosɹǝԀ sǝsn %(aWebsite)s" ],
   [ "<strong>Persona.</strong> Simplified sign-in, built by a non-profit. <a %s>Learn more&rarr;</a>",
     "<a %s>&rarr;ǝɹoɯ uɹaǝ⅂</a> .ʇıɟoɹd-uou a ʎq ʇʅınq ´uı-uƃıs pǝıɟıʅdɯıS <strong>.auosɹǝԀ</strong>" ],
-  [ "By proceeding, you agree to %(site)'s <a %(terms)>Terms</a> and <a %(privacy)>Privacy Policy</a>.",
-    ".<a %(privacy)>ʎɔıʅoԀ ʎɔaʌıɹԀ</a> pua <a %(terms)>sɯɹǝ⊥</a> s,%(site) oʇ ǝǝɹƃa noʎ ´ƃuıpǝǝɔoɹd ʎԐ" ]
+  [ "By proceeding, you agree to %(site)s's <a %(terms)s>Terms</a> and <a %(privacy)s>Privacy Policy</a>.",
+    ".<a %(privacy)s>ʎɔıʅoԀ ʎɔaʌıɹԀ</a> pua <a %(terms)s>sɯɹǝ⊥</a> s,%(site)s oʇ ǝǝɹƃa noʎ ´ƃuıpǝǝɔoɹd ʎԐ" ]
 ];
 
 var success = 0;


### PR DESCRIPTION
As mentioned in a [browserid bug](https://github.com/mozilla/browserid/issues/1322#issuecomment-12964919), the syntax of `format` has drifted from the original syntax.

This updates gobbledygook to use `%(foo)s` instead of `%(foo)`.
